### PR TITLE
Remove clj-parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,7 @@
+(def trapperkeeper-version "4.3.0")
+(def kitchensink-version "3.5.3")
+(def i18n-version "1.0.2")
+
 (defproject org.openvoxproject/trapperkeeper-filesystem-watcher "1.3.1-SNAPSHOT"
   :description "Trapperkeeper filesystem watcher service"
   :url "https://github.com/openvoxproject/trapperkeeper-filesystem-watcher"
@@ -6,18 +10,26 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project  {:coords [org.openvoxproject/clj-parent "7.6.3"]
-                    :inherit [:managed-dependencies]}
-
   :pedantic? :abort
 
+  ;; These are to enforce consistent versions across dependencies of dependencies,
+  ;; and to avoid having to define versions in multiple places. If a component
+  ;; defined under :dependencies ends up causing an error due to :pedantic? :abort,
+  ;; because it is a dep of a dep with a different version, move it here.
+  :managed-dependencies [[org.clojure/clojure "1.12.4"]
+
+                         [org.openvoxproject/kitchensink ~kitchensink-version]
+                         [org.openvoxproject/kitchensink ~kitchensink-version :classifier "test"]
+                         [org.openvoxproject/trapperkeeper ~trapperkeeper-version]
+                         [org.openvoxproject/trapperkeeper ~trapperkeeper-version :classifier "test"]]
+
   :dependencies [[org.clojure/clojure]
-                 [org.clojure/tools.logging]
-                 [prismatic/schema]
-                 [clj-commons/fs]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [prismatic/schema "1.1.12"]
+                 [clj-commons/fs "1.6.312"]
                  [org.openvoxproject/trapperkeeper]
                  [org.openvoxproject/kitchensink]
-                 [org.openvoxproject/i18n]]
+                 [org.openvoxproject/i18n ~i18n-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/CLOJARS_USERNAME
@@ -34,8 +46,7 @@
                                    :classifier "test"
                                    :scope "test"]]}}
 
-  :plugins  [[lein-parent "0.3.9"]
-             [jonase/eastwood "1.4.3"]
-             [org.openvoxproject/i18n "1.0.2"]]
+  :plugins  [[jonase/eastwood "1.4.3"]
+             [org.openvoxproject/i18n ~i18n-version]]
 
   :main puppetlabs.trapperkeeper.main)


### PR DESCRIPTION
In an effort to simplify our projects, this removes clj-parent and specifies dependency versions directly. Since we only have two top-level components (openvox-server and openvoxdb) and we use renovate to keep dependencies up to date, this introduces less churn and coordination when dependencies need updating.