### PR TITLE
Move version pins

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,3 @@
-(def trapperkeeper-version "4.3.2")
-(def kitchensink-version "3.5.5")
 (def i18n-version "1.0.3")
 
 (defproject org.openvoxproject/trapperkeeper-filesystem-watcher "1.5.2-SNAPSHOT"
@@ -12,25 +10,29 @@
 
   :pedantic? :abort
 
-  ;; These are to enforce consistent versions across dependencies of dependencies,
-  ;; and to avoid having to define versions in multiple places. If a component
-  ;; defined under :dependencies ends up causing an error due to :pedantic? :abort,
-  ;; because it is a dep of a dep with a different version, move it here.
+  ;; Generally, try to keep version pins in :managed-dependencies and the libraries
+  ;; this project actually uses in :dependencies, inheriting the version from
+  ;; :managed-dependencies. This prevents endless version conflicts due to deps of deps.
+  ;; Renovate should keep the versions largely in sync between projects.
   :managed-dependencies [[org.clojure/clojure "1.12.4"]
-                          [clj-time "0.15.2"]
+                         [org.clojure/tools.logging "1.3.1"]
 
-                         [org.openvoxproject/kitchensink ~kitchensink-version]
-                         [org.openvoxproject/kitchensink ~kitchensink-version :classifier "test"]
-                         [org.openvoxproject/trapperkeeper ~trapperkeeper-version]
-                         [org.openvoxproject/trapperkeeper ~trapperkeeper-version :classifier "test"]]
+                         [clj-commons/fs "1.6.312"]
+                         [clj-time "0.15.2"]
+                         [org.openvoxproject/kitchensink "3.5.5"]
+                         [org.openvoxproject/kitchensink "3.5.5" :classifier "test"]
+                         [org.openvoxproject/trapperkeeper "4.3.2"]
+                         [org.openvoxproject/trapperkeeper "4.3.2" :classifier "test"]
+                         [prismatic/schema "1.4.1"]]
 
   :dependencies [[org.clojure/clojure]
-                 [org.clojure/tools.logging "1.3.1"]
-                 [prismatic/schema "1.4.1"]
-                 [clj-commons/fs "1.6.312"]
+                 [org.clojure/tools.logging]
+
+                 [clj-commons/fs]
                  [org.openvoxproject/trapperkeeper]
                  [org.openvoxproject/kitchensink]
-                 [org.openvoxproject/i18n ~i18n-version]]
+                 [org.openvoxproject/i18n ~i18n-version]
+                 [prismatic/schema]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/CLOJARS_USERNAME


### PR DESCRIPTION
This moves the version pinning into managed-deps to avoid endless conflicts due to :pedantic? abort.